### PR TITLE
removed special link to propose a speaker

### DIFF
--- a/2014/events.xml
+++ b/2014/events.xml
@@ -61,7 +61,7 @@
     <latitude>53.5653</latitude>
     <longitude>10.0014</longitude>
     <registration><![CDATA[https://www.eventbrite.ca/e/locationtech-meetup-hamburg-tickets-12166226511]]></registration>
-    <body><![CDATA[Hamburg's LocationTech event will be a conference-style speaker series featuring technical talks/demos on the convergence of open source and geospatial.<br>Interested to present your project : register <a href="https://docs.google.com/forms/d/1uqqHpHjtiGCf5WGeNzn_oZWCh-fpAoO1h5s-VfF31sA/viewform">here</a> as a speaker.]]></body>
+    <body><![CDATA[Hamburg's LocationTech event will be a conference-style speaker series featuring technical talks/demos on the convergence of open source and geospatial.]]></body>
   </event>
   <event>
     <city>Ottawa</city>


### PR DESCRIPTION
link is available at Eventbrite-page itself (recently updated location, aganda, and other details)
